### PR TITLE
chore: update deps versions and bump version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule RabbitMQCloudWatchExporter.Mixfile do
   def project do
     [
       app: :rabbitmq_cloudwatch_exporter,
-      version: "1.0.0",
+      version: "1.0.1",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps_path: "deps",
@@ -26,7 +26,7 @@ defmodule RabbitMQCloudWatchExporter.Mixfile do
       {:ex_aws_cloudwatch, "~> 2.0.4"},
       {:singleton, "~> 1.2.0"},
       {:poison, "~> 3.0"},
-      {:hackney, "~> 1.15.2"},
+      {:hackney, "~> 1.16.0"},
       {
         :rabbit,
         path: Path.join(deps_dir, "rabbit"),


### PR DESCRIPTION
I guess this fixes #20 as it is reported in Elixir Forum that hackney 1.16.0 is working fine