### PR TITLE
Improve packaging (include deps)  and release workflows

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -1,0 +1,26 @@
+name: action
+on: [push]
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - erlang: "26.2"
+            elixir: "1.16.3"
+            rmqref: "v3.13.x"
+          - erlang: "26.2"
+            elixir: "1.17.3"
+            rmqref: "v4.0.x"
+          - erlang: "27.3.1"
+            elixir: "1.17.3"
+            rmqref: "v4.0.x"
+    uses: ./.github/workflows/build.yaml
+    with:
+      erlang: ${{ matrix.erlang }}
+      elixir: ${{ matrix.elixir }}
+      rmqref: ${{ matrix.rmqref }}
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    uses: ./.github/workflows/release.yaml
+    secrets: inherit

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -8,13 +8,16 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        erlang:
-          - '26.2'
-        elixir:
-          - '1.16.3'
-        rmqref:
-          - v3.13.x
-          - v4.0.x
+        include:
+          - erlang: "26.2"
+            elixir: "1.16.3"
+            rmqref: "v3.13.x"
+          - erlang: "26.2"
+            elixir: "1.17.3"
+            rmqref: "v4.0.x"
+          - erlang: "27.3.1"
+            elixir: "1.17.3"
+            rmqref: "v4.0.x"
     steps:
       - name: Checkout RabbitMQ Server
         uses: actions/checkout@v4
@@ -37,5 +40,5 @@ jobs:
       - name: Store build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: plugins-${{ matrix.rmqref }}
+          name: plugins-${{ matrix.rmqref }}-${{ matrix.erlang }}
           path: ${{ env.PLUGIN_FOLDER }}/plugins/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ${{ env.PLUGIN_FOLDER }}
+          fetch-depth: 0
+          fetch-tags: true
       - name: Install Erlang and Elixir
         uses: erlef/setup-beam@v1
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,23 +1,26 @@
 name: build
-on: [push, pull_request]
+on:
+  workflow_call:
+    inputs:
+      erlang:
+        required: true
+        type: string
+        default: "26.2"
+      elixir:
+        required: true
+        type: string
+        default: "1.16.3"
+      rmqref:
+        required: true
+        type: string
+        default: "v3.13.x"
+
 env:
   SERVER_FOLDER: rabbitmq-server
   PLUGIN_FOLDER: rabbitmq-server/deps/rabbitmq-cloudwatch-exporter
 jobs:
   build:
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        include:
-          - erlang: "26.2"
-            elixir: "1.16.3"
-            rmqref: "v3.13.x"
-          - erlang: "26.2"
-            elixir: "1.17.3"
-            rmqref: "v4.0.x"
-          - erlang: "27.3.1"
-            elixir: "1.17.3"
-            rmqref: "v4.0.x"
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout RabbitMQ Server
         uses: actions/checkout@v4
@@ -31,14 +34,14 @@ jobs:
       - name: Install Erlang and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{ matrix.erlang }}
-          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ inputs.erlang }}
+          elixir-version: ${{ inputs.elixir }}
       - name: Build distribution files
         working-directory: ${{ env.PLUGIN_FOLDER }}
         run: |
-          MIX_ENV=prod DIST_AS_EZS=yes make dist current_rmq_ref=${{ matrix.rmqref }}
+          MIX_ENV=prod DIST_AS_EZS=yes make dist current_rmq_ref=${{ inputs.rmqref }}
       - name: Store build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: plugins-${{ matrix.rmqref }}-${{ matrix.erlang }}
+          name: plugins-${{ inputs.rmqref }}-${{ inputs.erlang }}
           path: ${{ env.PLUGIN_FOLDER }}/plugins/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,22 @@
+name: release
+
+on:
+  workflow_call:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Build Artifacts
+        uses: dawidd6/action-download-artifact@v9
+        with:
+          path: artifacts/
+          skip_unpack: true
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: release ${{ github.ref_name }}
+          generate_release_notes: true
+          draft: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: artifacts/*.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM rabbitmq:4.0-management-alpine
+
+ARG CLOUDWATCH_EXPORTER_PLUGIN_VERSION=v1.0.6
+ARG CLOUDWATCH_EXPORTER_PLUGIN_FLAVOR=v4.0.x-27.3.1
+
+ENV RABBITMQ_PLUGINS_DIR=/opt/rabbitmq/plugins:/usr/lib/rabbitmq/plugins
+
+RUN apk --no-cache add curl zip
+
+#Install Cloudwatch rabbitmq plugin
+RUN curl -L -o ./cloudwatch-exporter.zip https://github.com/ZeroGachis/rabbitmq-cloudwatch-exporter/releases/download/${CLOUDWATCH_EXPORTER_PLUGIN_VERSION}/plugins-${CLOUDWATCH_EXPORTER_PLUGIN_FLAVOR}.zip \
+    && mkdir -p /usr/lib/rabbitmq/plugins \
+    && unzip ./cloudwatch-exporter.zip -d /usr/lib/rabbitmq/plugins/ \
+    && rm -rf cloudwatch-exporter.zip
+
+
+RUN rabbitmq-plugins enable rabbitmq_cloudwatch_exporter
+
+CMD ["rabbitmq-server"]

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ ARCHIVE_DIR  := $(PWD)/plugins
 # We need to instruct the `rabbitmq-dist:do-dist` target to not
 # remove our plugin and related dependencies.
 EXTRA_DIST_EZS = $(shell find $(ARCHIVE_DIR) -name '*.ez')
+
 app:: $(elixir_srcs) deps
 	$(MIX) make_app
 

--- a/Makefile
+++ b/Makefile
@@ -10,21 +10,25 @@ MIX_ENV      ?= dev
 override MIX := mix
 elixir_srcs  := mix.exs
 
+# Define archive directory
+ARCHIVE_DIR  := $(PWD)/plugins
+
 # RMQ `dist` target removes anything within the `plugins` folder
 # which is not managed by erlang.mk.
 # We need to instruct the `rabbitmq-dist:do-dist` target to not
 # remove our plugin and related dependencies.
-EXTRA_DIST_EZS = $(shell find $(PWD)/plugins -name *.ez)
+EXTRA_DIST_EZS = $(shell find $(ARCHIVE_DIR) -name *.ez)
 
 app:: $(elixir_srcs) deps
 	$(MIX) make_app
 
 dist:: app
 	mkdir -p $(DIST_DIR)
-	$(MIX) make_archives
+	ARCHIVE_DIR=$(ARCHIVE_DIR) $(MIX) make_archives
 
 clean::
 	@rm -fr _build
+	@rm -fr $(ARCHIVE_DIR)/*.ez
 
 include rabbitmq-components.mk
 include erlang.mk

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ ARCHIVE_DIR  := $(PWD)/plugins
 # which is not managed by erlang.mk.
 # We need to instruct the `rabbitmq-dist:do-dist` target to not
 # remove our plugin and related dependencies.
-EXTRA_DIST_EZS = $(shell find $(ARCHIVE_DIR) -name *.ez)
-
+EXTRA_DIST_EZS = $(shell find $(ARCHIVE_DIR) -name '*.ez')
 app:: $(elixir_srcs) deps
 	$(MIX) make_app
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Enable the plugin:
 [sudo] rabbitmq-plugins enable rabbitmq_cloudwatch_exporter
 ```
 
+you can also easily install the plugin inside RabbitMQ docker image. [Dockerfile](Dockerfile)
+
 ## Building from Source
 
 Please see RabbitMQ Plugin Development guide.
@@ -24,7 +26,7 @@ cd rabbitmq-cloudwatch-exporter
 make dist
 ```
 
-Then copy all the *.ez files inside the plugins folder to the [RabbitMQ plugins directory](http://www.rabbitmq.com/relocate.html) and enable the plugin:
+Then copy all the \*.ez files inside the plugins folder to the [RabbitMQ plugins directory](http://www.rabbitmq.com/relocate.html) and enable the plugin:
 
 ```bash
 [sudo] rabbitmq-plugins enable rabbitmq_cloudwatch_exporter
@@ -167,118 +169,118 @@ As AWS CloudWatch charges a [monthly cost](https://aws.amazon.com/cloudwatch/pri
 
 ##### Dimensions
 
-| Name        | Description       |
-| ----------- | ----------------- |
-| Metric      | "ClusterOverview" |
-| Cluster     | Cluster name      |
+| Name    | Description       |
+| ------- | ----------------- |
+| Metric  | "ClusterOverview" |
+| Cluster | Cluster name      |
 
 ##### Metrics
 
-| Name                       | Description                                                  |
-| -------------------------- | ------------------------------------------------------------ |
-| Messages                   | Total message count within the cluster                       |
-| MessagesReady              | Messages ready for deliver within the cluster                |
-| MessagesUnacknowledged     | Messages pending for acknowledgement within the cluster      |
-| Ack                        | Messages acknowledged                                        |
-| Confirm                    | Messages confirmed to publishers                             |
-| Deliver                    | Messages delivered to consumers                              |
-| DeliverGet                 | Messages delivered to consumers via basic.get                |
-| DeliverNoAck               | Messages delivered to consumers without acknowledgment       |
-| Get                        | Amount of basic.get requests                                 |
-| GetEmpty                   | Amount of basic.get requests over empty queue                |
-| GetNoAck                   | Amount of basic.get requests without acknowledgement         |
-| Publish                    | Messages published within the channel                        |
-| Redeliver                  | Messages redelivered                                         |
-| ReturnUnroutable           | Messages returned as non routable                            |
+| Name                   | Description                                             |
+| ---------------------- | ------------------------------------------------------- |
+| Messages               | Total message count within the cluster                  |
+| MessagesReady          | Messages ready for deliver within the cluster           |
+| MessagesUnacknowledged | Messages pending for acknowledgement within the cluster |
+| Ack                    | Messages acknowledged                                   |
+| Confirm                | Messages confirmed to publishers                        |
+| Deliver                | Messages delivered to consumers                         |
+| DeliverGet             | Messages delivered to consumers via basic.get           |
+| DeliverNoAck           | Messages delivered to consumers without acknowledgment  |
+| Get                    | Amount of basic.get requests                            |
+| GetEmpty               | Amount of basic.get requests over empty queue           |
+| GetNoAck               | Amount of basic.get requests without acknowledgement    |
+| Publish                | Messages published within the channel                   |
+| Redeliver              | Messages redelivered                                    |
+| ReturnUnroutable       | Messages returned as non routable                       |
 
 #### VHost
 
 ##### Dimensions
 
-| Name        | Description       |
-| ----------- | ----------------- |
-| Metric      | "VHost"           |
-| Cluster     | Cluster name      |
-| VHost       | Virtual Host name |
+| Name    | Description       |
+| ------- | ----------------- |
+| Metric  | "VHost"           |
+| Cluster | Cluster name      |
+| VHost   | Virtual Host name |
 
 ##### Metrics
 
-| Name                       | Description                                                  |
-| -------------------------- | ------------------------------------------------------------ |
-| Messages                   | Total message count within the vhost                         |
-| MessagesReady              | Messages ready for deliver within the vhost                  |
-| MessagesUnacknowledged     | Messages pending for acknowledgement within the vhost        |
-| Ack                        | Messages acknowledged                                        |
-| Confirm                    | Messages confirmed to publishers                             |
-| Deliver                    | Messages delivered to consumers                              |
-| DeliverGet                 | Messages delivered to consumers via basic.get                |
-| DeliverNoAck               | Messages delivered to consumers without acknowledgment       |
-| Get                        | Amount of basic.get requests                                 |
-| GetEmpty                   | Amount of basic.get requests over empty queue                |
-| GetNoAck                   | Amount of basic.get requests without acknowledgement         |
-| Publish                    | Messages published within the channel                        |
-| Redeliver                  | Messages redelivered                                         |
-| ReturnUnroutable           | Messages returned as non routable                            |
+| Name                   | Description                                            |
+| ---------------------- | ------------------------------------------------------ |
+| Messages               | Total message count within the vhost                   |
+| MessagesReady          | Messages ready for deliver within the vhost            |
+| MessagesUnacknowledged | Messages pending for acknowledgement within the vhost  |
+| Ack                    | Messages acknowledged                                  |
+| Confirm                | Messages confirmed to publishers                       |
+| Deliver                | Messages delivered to consumers                        |
+| DeliverGet             | Messages delivered to consumers via basic.get          |
+| DeliverNoAck           | Messages delivered to consumers without acknowledgment |
+| Get                    | Amount of basic.get requests                           |
+| GetEmpty               | Amount of basic.get requests over empty queue          |
+| GetNoAck               | Amount of basic.get requests without acknowledgement   |
+| Publish                | Messages published within the channel                  |
+| Redeliver              | Messages redelivered                                   |
+| ReturnUnroutable       | Messages returned as non routable                      |
 
 #### Node
 
 ##### Dimensions
 
-| Name        | Description              |
-| ----------- | ------------------------ |
-| Metric      | "Node"                   |
-| Cluster     | Cluster name             |
-| Node        | Node name                |
-| Type        | Node type (disk\|memory) |
-| Limit       | Limit when applicable    |
+| Name    | Description              |
+| ------- | ------------------------ |
+| Metric  | "Node"                   |
+| Cluster | Cluster name             |
+| Node    | Node name                |
+| Type    | Node type (disk\|memory) |
+| Limit   | Limit when applicable    |
 
 ##### Metrics
 
-| Name                    | Description                                  |
-| ----------------------- | -------------------------------------------- |
-| Uptime                  | Node uptime in milliseconds                  |
-| Memory                  | Memory in use                                |
-| DiskFree                | Amount of free disk                          |
-| FileDescriptors         | Open file descriptors                        |
-| Sockets                 | Open sockets                                 |
-| Processes               | Erlang Processes                             |
-| IORead                  | I/O read count                               |
-| BytesIORead             | I/O read in bytes                            |
-| IOWrite                 | I/O write count                              |
-| BytesIOWrite            | I/O write in bytes                           |
-| IOSeek                  | I/O seek count                               |
-| MnesiaRamTransactions   | Mnesia transaction count on memory tables    |
-| MnesiaDiskTransactions  | Mnesia transaction count on disk tables      |
+| Name                   | Description                               |
+| ---------------------- | ----------------------------------------- |
+| Uptime                 | Node uptime in milliseconds               |
+| Memory                 | Memory in use                             |
+| DiskFree               | Amount of free disk                       |
+| FileDescriptors        | Open file descriptors                     |
+| Sockets                | Open sockets                              |
+| Processes              | Erlang Processes                          |
+| IORead                 | I/O read count                            |
+| BytesIORead            | I/O read in bytes                         |
+| IOWrite                | I/O write count                           |
+| BytesIOWrite           | I/O write in bytes                        |
+| IOSeek                 | I/O seek count                            |
+| MnesiaRamTransactions  | Mnesia transaction count on memory tables |
+| MnesiaDiskTransactions | Mnesia transaction count on disk tables   |
 
 #### Exchange
 
 ##### Dimensions
 
-| Name        | Description                                  |
-| ----------- | -------------------------------------------- |
-| Metric      | "Exchange"                                   |
-| Cluster     | Cluster name                                 |
-| Exchange    | Exchange name, `_` for the default exchange  |
-| Type        | Exchange type (direct\|fanout\|...)          |
-| VHost       | VHost where the exchange belongs             |
+| Name     | Description                                 |
+| -------- | ------------------------------------------- |
+| Metric   | "Exchange"                                  |
+| Cluster  | Cluster name                                |
+| Exchange | Exchange name, `_` for the default exchange |
+| Type     | Exchange type (direct\|fanout\|...)         |
+| VHost    | VHost where the exchange belongs            |
 
 ##### Metrics
 
-| Name                    | Description                                  |
-| ----------------------- | -------------------------------------------- |
-| PublishIn               | Messages published within the exchange       |
-| PublishOut              | Messages published by the exchange           |
+| Name       | Description                            |
+| ---------- | -------------------------------------- |
+| PublishIn  | Messages published within the exchange |
+| PublishOut | Messages published by the exchange     |
 
 #### Queue
 
 ##### Dimensions
 
-| Name        | Description                       |
-| ----------- | --------------------------------- |
-| Metric      | "Queue"                           |
-| Cluster     | Cluster name                      |
-| Queue       | Queue name                        |
-| VHost       | VHost where the queue belongs     |
+| Name    | Description                   |
+| ------- | ----------------------------- |
+| Metric  | "Queue"                       |
+| Cluster | Cluster name                  |
+| Queue   | Queue name                    |
+| VHost   | VHost where the queue belongs |
 
 ##### Metrics
 
@@ -304,58 +306,58 @@ As AWS CloudWatch charges a [monthly cost](https://aws.amazon.com/cloudwatch/pri
 
 ##### Dimensions
 
-| Name                    | Description                                      |
-| ----------------------- | ------------------------------------------------ |
-| Metric                  | "Connection"                                     |
-| Cluster                 | Cluster name                                     |
-| Connection              | IP:Port -> IP:port                               |
-| Protocol                | Used protocol (AMQP 0-9-1\|AMQP 1.0\|STOMP\|...) |
-| Node                    | Node where the connection is attached to         |
-| VHost                   | VHost where the connection is attached to        |
-| User                    | Username used to connect                         |
-| AuthMechanism           | Employed authentication mechanism                |
+| Name          | Description                                      |
+| ------------- | ------------------------------------------------ |
+| Metric        | "Connection"                                     |
+| Cluster       | Cluster name                                     |
+| Connection    | IP:Port -> IP:port                               |
+| Protocol      | Used protocol (AMQP 0-9-1\|AMQP 1.0\|STOMP\|...) |
+| Node          | Node where the connection is attached to         |
+| VHost         | VHost where the connection is attached to        |
+| User          | Username used to connect                         |
+| AuthMechanism | Employed authentication mechanism                |
 
 ##### Metrics
 
-| Name                    | Description                                   |
-| ----------------------- | --------------------------------------------- |
-| Channels                | Opened channels count                         |
-| Sent                    | Packets sent                                  |
-| BytesSent               | Bytes sent                                    |
-| Received                | Packets received                              |
-| BytesReceived           | Bytes received                                |
+| Name          | Description           |
+| ------------- | --------------------- |
+| Channels      | Opened channels count |
+| Sent          | Packets sent          |
+| BytesSent     | Bytes sent            |
+| Received      | Packets received      |
+| BytesReceived | Bytes received        |
 
 #### Channel
 
 ##### Dimensions
 
-| Name                    | Description                                      |
-| ----------------------- | ------------------------------------------------ |
-| Metric                  | "Channel"                                        |
-| Cluster                 | Cluster name                                     |
-| Connection              | IP:Port -> IP:port                               |
-| Channel                 | IP:Port -> IP:port (channels on the connection)  |
-| VHost                   | VHost where the connection is attached to        |
-| User                    | Username used to connect                         |
+| Name       | Description                                     |
+| ---------- | ----------------------------------------------- |
+| Metric     | "Channel"                                       |
+| Cluster    | Cluster name                                    |
+| Connection | IP:Port -> IP:port                              |
+| Channel    | IP:Port -> IP:port (channels on the connection) |
+| VHost      | VHost where the connection is attached to       |
+| User       | Username used to connect                        |
 
 ##### Metrics
 
-| Name                       | Description                                                  |
-| -------------------------- | ------------------------------------------------------------ |
-| MessagesUnacknowledged     | Messages pending acknowledgement on the channel              |
-| MessagesUnconfirmed        | Messages unconfirmed on the channel                          |
-| MessagesUncommitted        | Messages uncommitted on the channel                          |
-| AknogwledgesUncommitted    | Acknowledgements uncommitted on the channel                  |
-| PrefetchCount              | Prefetch count (QoS) configured on the channel               |
-| GlobalPrefetchCount        | Global prefetch count (QoS) configured on the channel        |
-| Ack                        | Messages acknowledged                                        |
-| Confirm                    | Messages confirmed to publishers                             |
-| Deliver                    | Messages delivered to consumers                              |
-| DeliverGet                 | Messages delivered to consumers via basic.get                |
-| DeliverNoAck               | Messages delivered to consumers without acknowledgment       |
-| Get                        | Amount of basic.get requests                                 |
-| GetEmpty                   | Amount of basic.get requests over empty queue                |
-| GetNoAck                   | Amount of basic.get requests without acknowledgement         |
-| Publish                    | Messages published within the channel                        |
-| Redeliver                  | Messages redelivered                                         |
-| ReturnUnroutable           | Messages returned as non routable                            |
+| Name                    | Description                                            |
+| ----------------------- | ------------------------------------------------------ |
+| MessagesUnacknowledged  | Messages pending acknowledgement on the channel        |
+| MessagesUnconfirmed     | Messages unconfirmed on the channel                    |
+| MessagesUncommitted     | Messages uncommitted on the channel                    |
+| AknogwledgesUncommitted | Acknowledgements uncommitted on the channel            |
+| PrefetchCount           | Prefetch count (QoS) configured on the channel         |
+| GlobalPrefetchCount     | Global prefetch count (QoS) configured on the channel  |
+| Ack                     | Messages acknowledged                                  |
+| Confirm                 | Messages confirmed to publishers                       |
+| Deliver                 | Messages delivered to consumers                        |
+| DeliverGet              | Messages delivered to consumers via basic.get          |
+| DeliverNoAck            | Messages delivered to consumers without acknowledgment |
+| Get                     | Amount of basic.get requests                           |
+| GetEmpty                | Amount of basic.get requests over empty queue          |
+| GetNoAck                | Amount of basic.get requests without acknowledgement   |
+| Publish                 | Messages published within the channel                  |
+| Redeliver               | Messages redelivered                                   |
+| ReturnUnroutable        | Messages returned as non routable                      |

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,10 @@ defmodule RabbitMQCloudWatchExporter.Mixfile do
     ]
   end
 
+  defp archive_dir do
+    System.get_env("ARCHIVE_DIR", ".")
+  end
+  
   defp aliases do
     [
       make_deps: [
@@ -43,9 +47,9 @@ defmodule RabbitMQCloudWatchExporter.Mixfile do
         "compile"
       ],
       make_archives: [
-        "archive.build.deps",
-        "archive.build.elixir",
-        "archive.build.all"
+        "archive.build.deps --destination=#{archive_dir()}",
+        "archive.build.elixir --destination=#{archive_dir()}",
+        "archive.build.all --destination=#{archive_dir()}"
       ]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule RabbitMQCloudWatchExporter.Mixfile do
   def project do
     [
       app: :rabbitmq_cloudwatch_exporter,
-      version: "1.0.5",
+      version: get_version(),
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps("deps"),
@@ -20,6 +20,14 @@ defmodule RabbitMQCloudWatchExporter.Mixfile do
     ]
   end
 
+  # Get version directly from git tag
+  defp get_version do
+    {tag, 0} = System.cmd("git", ["describe", "--tags", "--abbrev=0"], stderr_to_stdout: true)
+    tag
+    |> String.trim()
+    |> String.replace_prefix("v", "") 
+  end
+
   defp deps(deps_dir) do
     [
       {:ex_aws, "~> 2.5.7"},
@@ -32,7 +40,7 @@ defmodule RabbitMQCloudWatchExporter.Mixfile do
   end
 
   defp archive_dir do
-    System.get_env("ARCHIVE_DIR", ".")
+    System.get_env("ARCHIVE_DIR", "plugins")
   end
   
   defp aliases do

--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -1,12 +1,201 @@
-# Inspired by erlang.mk bootstrap Makefile.
-# Fetch updated rabbitmq-components.mk from rabbitmq-common.
+ifeq ($(.DEFAULT_GOAL),)
+# Define default goal to `all` because this file defines some targets
+# before the inclusion of erlang.mk leading to the wrong target becoming
+# the default.
+.DEFAULT_GOAL = all
+endif
 
-RABBITMQ_COMMON_DIR ?= .rabbitmq-components.mk.build
+# PROJECT_VERSION defaults to:
+#   1. the version exported by environment;
+#   2. the version stored in `git-revisions.txt`, if it exists;
+#   3. a version based on git-describe(1), if it is a Git clone;
+#   4. 0.0.0
+#
+# Note that in the case where git-describe(1) is used
+# (e.g. during development), running "git gc" may help
+# improve the performance.
 
-rabbitmq-components.mk: rabbitmq-components-bootstrap
-	git clone https://github.com/rabbitmq/rabbitmq-server $(RABBITMQ_COMMON_DIR)
-	cp $(RABBITMQ_COMMON_DIR)/rabbitmq-components.mk ./rabbitmq-components.mk
-	rm -rf $(RABBITMQ_COMMON_DIR)
+PROJECT_VERSION := $(RABBITMQ_VERSION)
 
-.PHONY: rabbitmq-components-bootstrap
-rabbitmq-components-bootstrap: ;
+ifeq ($(PROJECT_VERSION),)
+ifneq ($(wildcard git-revisions.txt),)
+PROJECT_VERSION = $(shell \
+	head -n1 git-revisions.txt | \
+	awk '{print $$$(words $(PROJECT_DESCRIPTION) version);}')
+else
+PROJECT_VERSION = $(shell \
+	git describe --abbrev=0 --tags \
+		2>/dev/null | sed 's/^v//' || echo 0.0.0)
+endif
+endif
+
+# --------------------------------------------------------------------
+# RabbitMQ components.
+# --------------------------------------------------------------------
+
+# Third-party dependencies version pinning.
+#
+# We do that in this file, which is included by all projects, to ensure
+# all projects use the same versions. It avoids conflicts.
+
+dep_accept = hex 0.3.5
+dep_cowboy = hex 2.13.0
+dep_cowlib = hex 2.14.0
+dep_credentials_obfuscation = hex 3.5.0
+dep_cuttlefish = hex 3.4.0
+dep_gen_batch_server = hex 0.8.8
+dep_jose = hex 1.11.10
+dep_khepri = hex 0.16.0
+dep_khepri_mnesia_migration = hex 0.7.1
+dep_meck = hex 1.0.0
+dep_osiris = git https://github.com/rabbitmq/osiris v1.8.6
+dep_prometheus = hex 4.11.0
+dep_ra = hex 2.16.6
+dep_ranch = hex 2.2.0
+dep_recon = hex 2.5.6
+dep_redbug = hex 2.0.7
+dep_systemd = hex 0.6.1
+dep_thoas = hex 1.2.1
+dep_observer_cli = hex 1.8.2
+dep_seshat = git https://github.com/rabbitmq/seshat v0.6.1
+dep_stdout_formatter = hex 0.2.4
+dep_sysmon_handler = hex 1.3.0
+
+# RabbitMQ applications found in the monorepo.
+#
+# Note that rabbitmq_server_release is not a real application
+# but is the name used in the top-level Makefile.
+
+RABBITMQ_BUILTIN = \
+	amqp10_client \
+	amqp10_common \
+	amqp_client \
+	oauth2_client \
+	rabbit \
+	rabbit_common \
+	rabbitmq_amqp1_0 \
+	rabbitmq_amqp_client \
+	rabbitmq_auth_backend_cache \
+	rabbitmq_auth_backend_http \
+	rabbitmq_auth_backend_ldap \
+	rabbitmq_auth_backend_oauth2 \
+	rabbitmq_auth_mechanism_ssl \
+	rabbitmq_aws \
+	rabbitmq_cli \
+	rabbitmq_codegen \
+	rabbitmq_consistent_hash_exchange \
+	rabbitmq_ct_client_helpers \
+	rabbitmq_ct_helpers \
+	rabbitmq_event_exchange \
+	rabbitmq_federation \
+	rabbitmq_federation_management \
+	rabbitmq_federation_prometheus \
+	rabbitmq_jms_topic_exchange \
+	rabbitmq_management \
+	rabbitmq_management_agent \
+	rabbitmq_mqtt \
+	rabbitmq_peer_discovery_aws \
+	rabbitmq_peer_discovery_common \
+	rabbitmq_peer_discovery_consul \
+	rabbitmq_peer_discovery_etcd \
+	rabbitmq_peer_discovery_k8s \
+	rabbitmq_prelaunch \
+	rabbitmq_prometheus \
+	rabbitmq_random_exchange \
+	rabbitmq_recent_history_exchange \
+    rabbitmq_server_release \
+	rabbitmq_sharding \
+	rabbitmq_shovel \
+	rabbitmq_shovel_management \
+	rabbitmq_stomp \
+	rabbitmq_stream \
+	rabbitmq_stream_common \
+	rabbitmq_stream_management \
+	rabbitmq_top \
+	rabbitmq_tracing \
+	rabbitmq_trust_store \
+	rabbitmq_web_dispatch \
+	rabbitmq_web_mqtt \
+	rabbitmq_web_mqtt_examples \
+	rabbitmq_web_stomp \
+	rabbitmq_web_stomp_examples \
+	trust_store_http
+
+# Applications outside of the monorepo maintained by Team RabbitMQ.
+
+RABBITMQ_COMMUNITY = \
+	rabbitmq_auth_backend_amqp \
+	rabbitmq_boot_steps_visualiser \
+	rabbitmq_delayed_message_exchange \
+	rabbitmq_lvc_exchange \
+	rabbitmq_management_exchange \
+	rabbitmq_management_themes \
+	rabbitmq_message_timestamp \
+	rabbitmq_metronome \
+	rabbitmq_routing_node_stamp \
+	rabbitmq_rtopic_exchange
+
+community_dep = git git@github.com:rabbitmq/$1.git $(if $2,$2,main)
+dep_rabbitmq_auth_backend_amqp = $(call community_dep,rabbitmq-auth-backend-amqp)
+dep_rabbitmq_boot_steps_visualiser = $(call community_dep,rabbitmq-boot-steps-visualiser,master)
+dep_rabbitmq_delayed_message_exchange = $(call community_dep,rabbitmq-delayed-message-exchange)
+dep_rabbitmq_lvc_exchange = $(call community_dep,rabbitmq-lvc-exchange)
+dep_rabbitmq_management_exchange = $(call community_dep,rabbitmq-management-exchange)
+dep_rabbitmq_management_themes = $(call community_dep,rabbitmq-management-themes,master)
+dep_rabbitmq_message_timestamp = $(call community_dep,rabbitmq-message-timestamp)
+dep_rabbitmq_metronome = $(call community_dep,rabbitmq-metronome,master)
+dep_rabbitmq_routing_node_stamp = $(call community_dep,rabbitmq-routing-node-stamp)
+dep_rabbitmq_rtopic_exchange = $(call community_dep,rabbitmq-rtopic-exchange)
+
+# All RabbitMQ applications.
+
+RABBITMQ_COMPONENTS = $(RABBITMQ_BUILTIN) $(RABBITMQ_COMMUNITY)
+
+# Erlang.mk does not rebuild dependencies by default, once they were
+# compiled once, except for those listed in the `$(FORCE_REBUILD)`
+# variable.
+#
+# We want all RabbitMQ components to always be rebuilt: this eases
+# the work on several components at the same time.
+
+FORCE_REBUILD = $(RABBITMQ_COMPONENTS)
+
+# We disable autopatching for community plugins as they sit in
+# their own repository and we want to avoid polluting the git
+# status with changes that should not be committed.
+NO_AUTOPATCH += $(RABBITMQ_COMMUNITY)
+
+# --------------------------------------------------------------------
+# Component distribution.
+# --------------------------------------------------------------------
+
+list-dist-deps::
+	@:
+
+prepare-dist::
+	@:
+
+# --------------------------------------------------------------------
+# RabbitMQ-specific settings.
+# --------------------------------------------------------------------
+
+# If the top-level project is a RabbitMQ component, we override
+# $(DEPS_DIR) for this project to point to the top-level's one.
+#
+# We do the same for $(ERLANG_MK_TMP) as we want to keep the
+# beam cache regardless of where we build. We also want to
+# share Hex tarballs.
+
+ifneq ($(PROJECT),rabbitmq_server_release)
+DEPS_DIR ?= $(abspath ..)
+ERLANG_MK_TMP ?= $(abspath ../../.erlang.mk)
+DISABLE_DISTCLEAN = 1
+endif
+
+# We disable `make distclean` so $(DEPS_DIR) is not accidentally removed.
+
+ifeq ($(DISABLE_DISTCLEAN),1)
+ifneq ($(filter distclean distclean-deps,$(MAKECMDGOALS)),)
+SKIP_DEPS = 1
+endif
+endif


### PR DESCRIPTION
Hi,
Thank you for all your work on this plugin. We've been using it successfully for several years!

The latest version doesn't include dependencies directly in the rabbitmq-cloudwatch-exporter package, which has been challenging for us. I've made a small update to include these dependencies again.

Additional improvements in this PR:
- Added package support for RabbitMQ v4 with Erlang v27.3.1
- Implemented an automated GitHub release workflow: when a tag is created, a draft release is automatically generated with all packages built by the CI attached as assets
![image](https://github.com/user-attachments/assets/e78b7b6a-0c11-44d6-ab2f-ec1d9be569c7)

I plan to open another PR with a Dockerfile template to make using this plugin even easier.

Please let me know if you have any questions about these changes.